### PR TITLE
Avoid infinite recursion when retrieving character map data

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Providers/DefaultAssetProvider.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Providers/DefaultAssetProvider.cs
@@ -38,6 +38,7 @@ namespace SpriterDotNet.Providers
             if (CharMapValues.ContainsKey(asset))
             {
                 KeyValuePair<int, int> mapping = CharMapValues[asset];
+                if (mapping.Key == folderId && mapping.Value == fileId) return asset;
                 return Get(mapping.Key, mapping.Value);
             }
 


### PR DESCRIPTION
Change missed in 57914c70ad158ea592b58848976f4c0645ebd866.
Spriter allows character maps which map sprite from folder to the same
sprite in the same folder.