### PR TITLE
Process only files by spriter importer

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterImporter.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterImporter.cs
@@ -39,7 +39,12 @@ namespace SpriterDotNetUnity
 
         private static bool IsScml(string path)
         {
-            return ScmlExtensions.Any(path.EndsWith) && !path.EndsWith(AutosaveExtension);
+            return IsFile(path) && ScmlExtensions.Any(path.EndsWith) && !path.EndsWith(AutosaveExtension);
+        }
+
+        private static bool IsFile(string path)
+        {
+            return (File.GetAttributes(path) & FileAttributes.Directory) != FileAttributes.Directory;
         }
 
         private static void CreateSpriter(string path)


### PR DESCRIPTION
Unity imports folders and folder path is passed to `OnPostprocessAllAssets` method. If folder name ends with `.scml`, `SpriterImporter` tried to import it as `.scml` file which led to `UnauthorizedAccessException ` when calling `File.ReadAllText` in `CreateSpriter` method.

This pull request extends scml asset check to avoid such folders.

