### PR TITLE
Set initial value for SortingLayer field

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterDotNetBehaviour.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterDotNetBehaviour.cs
@@ -29,7 +29,7 @@ namespace SpriterDotNetUnity
     public class SpriterDotNetBehaviour : MonoBehaviour
     {
         [HideInInspector]
-        public string SortingLayer;
+        public string SortingLayer = "Default";
 
         [HideInInspector]
         public int SortingOrder;


### PR DESCRIPTION
To have initial field value serialized when prefab is generated for the first time. Otherwise field would not be set in prefab. If prefab is added to source control right after generation, one would observe prefab changes in the future if select prefab in Unity project window and save it since field would be set by custom editor [here](https://github.com/loodakrawa/SpriterDotNet/blob/develop/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterDotNetBehaviourEditor.cs#L35).

Sadly there is no Unity API to retrive default sorting layer name (i.e. `"Default"`) so use string literal for that.