### PR TITLE
Change prefab replace option to ReplaceNameBased

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterImporter.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterImporter.cs
@@ -126,7 +126,7 @@ namespace SpriterDotNetUnity
             sdnbExisting.SpriterData = sdnbNew.SpriterData;
             sdnbExisting.UseNativeTags = sdnbNew.UseNativeTags;
 
-            GameObject createdPrefab = PrefabUtility.ReplacePrefab(existing, prefab, ReplacePrefabOptions.Default);
+            GameObject createdPrefab = PrefabUtility.ReplacePrefab(existing, prefab, ReplacePrefabOptions.ReplaceNameBased);
             GameObject.DestroyImmediate(existing);
             return createdPrefab;
         }


### PR DESCRIPTION
This ensures prefab reference as serialize field in another object persists on corresponding .scml file reimport.

For example, imaging having behaviour like this
```csharp
using UnityEngine;
using SpriterDotNetUnity;

public class SDNBehTest : MonoBehaviour
{
    [SerializeField]
    private SpriterDotNetBehaviour sdnPrefab;
}
```
And prefab generated by SpriterDotNet linked to `sdnPrefab` field in the scene. Reimporting `.scml` file will result in `PrefabUtility.ReplacePrefab` called with `ReplacePrefabOptions.Default` which results into prefab reference being lost for `SDNBehTest` in the scene.

Another thing. Even if prefab references is not the case for the project (for example prefabs are loaded via `Resources` by path), reimporting with `ReplacePrefabOptions.Default` results in internal prefab structure being changed dramatically on `.scml` file reimport (and source control diff would report that). This is undesired behavior for the case of `.scml` file was not changed.

Closes #73.