### PR TITLE
Unity sorting updates

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterDotNetBehaviourEditor.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/SpriterDotNetBehaviourEditor.cs
@@ -6,29 +6,22 @@
 #if UNITY_EDITOR
 
 using System;
-using System.Reflection;
+using System.Linq;
 using UnityEditor;
-using UnityEditorInternal;
+using UnityEngine;
 
 namespace SpriterDotNetUnity
 {
     [CustomEditor(typeof(SpriterDotNetBehaviour))]
     public class SpriterDotNetBehaviourEditor : Editor
     {
-        private string[] GetSortingLayerNames()
-        {
-            Type internalEditorUtilityType = typeof(InternalEditorUtility);
-            PropertyInfo sortingLayersProperty = internalEditorUtilityType.GetProperty("sortingLayerNames", BindingFlags.Static | BindingFlags.NonPublic);
-            return (string[])sortingLayersProperty.GetValue(null, new object[0]);
-        }
-
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
 
             SpriterDotNetBehaviour sdnb = target as SpriterDotNetBehaviour;
 
-            string[] layers = GetSortingLayerNames();
+            string[] layers = SortingLayer.layers.Select(l => l.name).ToArray();
             int currentIndex = Array.IndexOf(layers, sdnb.SortingLayer);
             if (currentIndex < 0) currentIndex = 0;
             int choiceIndex = EditorGUILayout.Popup("Sorting Layer", currentIndex, layers);

--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/UnityAnimator.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/UnityAnimator.cs
@@ -94,7 +94,7 @@ namespace SpriterDotNetUnity
             childTransform.localScale = new Vector3(info.ScaleX, info.ScaleY, 1);
 
             renderer.sortingLayerName = SortingLayer;
-            renderer.sortingOrder = SortingOrder * renderers.Length + index;
+            renderer.sortingOrder = SortingOrder + index;
 
             ++index;
         }


### PR DESCRIPTION
* Get sorting layer names for SpriterDotNetBehaviour custom editor w/o reflection. Sadly, Unity's `EditorGUILayout` does not have sorting layer name field method.
* Change `UnityAnimator` formula for sorting order of the renderer. Now renderes will have order values based on sorting order of SpriterDotNetBehaviour. For example, if sorting order of behaviour is 100, renderers orders will be 101, 102, 103 etc. Before they had values dependant on the number of renderers. I would say this values make more sense than multiplying sorting order by number of renderes. Please correct me if I'm wrong.