### PR TITLE
interpolation of Alpha values on Transformations

### DIFF
--- a/SpriterDotNet/Helpers/SpriterHelper.cs
+++ b/SpriterDotNet/Helpers/SpriterHelper.cs
@@ -82,6 +82,7 @@ namespace SpriterDotNet.Helpers
             child.ScaleY *= parent.ScaleY;
             child.Angle = parent.Angle + Math.Sign(parent.ScaleX * parent.ScaleY) * child.Angle;
             child.Angle %= 360.0f;
+            child.Alpha = parent.Alpha * child.Alpha;
         }
 
         /// <summary>
@@ -134,6 +135,7 @@ namespace SpriterDotNet.Helpers
             target.Y = MathHelper.Linear(a.Y, b.Y, factor);
             target.ScaleX = MathHelper.Linear(a.ScaleX, b.ScaleX, factor);
             target.ScaleY = MathHelper.Linear(a.ScaleY, b.ScaleY, factor);
+            target.Alpha = MathHelper.Linear(a.Alpha, b.Alpha, factor);
         }
 
         /// <summary>


### PR DESCRIPTION
I added interpolation of Alpha values on transformation. This does not make much sense but I got some Spriter-Animations where the Alpha-value of "bones" where animated. This did not get applied otherwise.
Discard the PR if you think, it is not useful