### PR TITLE
Major changes in duplicate key handling

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/FrameDataCalculator.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/FrameDataCalculator.cs
@@ -333,6 +333,13 @@ namespace SpriterDotNet
             int nextKey = keyA.Id + 1;
             if (nextKey >= keys.Length) nextKey = 0;
             keyB = keys[nextKey];
+            if (keyA.Time == keyB.Time)
+            {
+                ++nextKey;
+                if (nextKey >= keys.Length) nextKey = 0;
+                keyB = keys[nextKey];
+            }
+
         }
 
         protected virtual SpriterSpatial GetBoneInfo(SpriterRef spriterRef, SpriterAnimation animation, float targetTime)

--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Helpers/SpriterHelper.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Helpers/SpriterHelper.cs
@@ -46,7 +46,21 @@ namespace SpriterDotNet.Helpers
                 keyBId = 0;
             }
 
-            return keys[keyBId];
+            var nextKey = keys[keyBId];
+            if (firstKey.Time == nextKey.Time)
+            {
+                ++keyBId;
+                if (keyBId >= keys.Length)
+                {
+                    if (!looping) return null;
+                    keyBId = 0;
+                }
+                return keys[keyBId];
+            }
+            else
+            {
+                return nextKey;
+            }
         }
 
         /// <summary>
@@ -193,7 +207,7 @@ namespace SpriterDotNet.Helpers
         /// </summary>
         public static float AdjustTime(float targetTime, SpriterKey keyA, SpriterKey keyB, float animationLength)
         {
-            float nextTime = keyB.Time > keyA.Time ? keyB.Time : animationLength;
+            float nextTime = GetNextTime(keyA, keyB, animationLength);
             float factor = GetFactor(keyA, keyB, animationLength, targetTime);
             return MathHelper.Linear(keyA.Time, nextTime, factor);
         }
@@ -209,12 +223,35 @@ namespace SpriterDotNet.Helpers
             if (timeA > timeB)
             {
                 timeB += animationLength;
+                if (timeA == timeB)
+                {
+                    timeB += animationLength;
+                }
                 if (targetTime < timeA) targetTime += animationLength;
             }
 
             float factor = MathHelper.GetFactor(timeA, timeB, targetTime);
             factor = AdjustFactor(factor, keyA);
             return factor;
+        }
+
+        /// <summary>
+        /// Gets next time for the two keys based on relative keys timeline position.
+        /// </summary>
+        private static float GetNextTime(SpriterKey keyA, SpriterKey keyB, float animationLength)
+        {
+            if (keyA.Time < keyB.Time)
+            {
+                return keyB.Time;
+            }
+            else if (keyB.Time + animationLength == keyA.Time)
+            {
+                return keyA.Time + animationLength;
+            }
+            else
+            {
+                return animationLength;
+            }
         }
     }
 }

--- a/SpriterDotNet/FrameDataCalculator.cs
+++ b/SpriterDotNet/FrameDataCalculator.cs
@@ -333,6 +333,13 @@ namespace SpriterDotNet
             int nextKey = keyA.Id + 1;
             if (nextKey >= keys.Length) nextKey = 0;
             keyB = keys[nextKey];
+            if (keyA.Time == keyB.Time)
+            {
+                ++nextKey;
+                if (nextKey >= keys.Length) nextKey = 0;
+                keyB = keys[nextKey];
+            }
+
         }
 
         protected virtual SpriterSpatial GetBoneInfo(SpriterRef spriterRef, SpriterAnimation animation, float targetTime)

--- a/SpriterDotNet/Helpers/SpriterHelper.cs
+++ b/SpriterDotNet/Helpers/SpriterHelper.cs
@@ -46,7 +46,21 @@ namespace SpriterDotNet.Helpers
                 keyBId = 0;
             }
 
-            return keys[keyBId];
+            var nextKey = keys[keyBId];
+            if (firstKey.Time == nextKey.Time)
+            {
+                ++keyBId;
+                if (keyBId >= keys.Length)
+                {
+                    if (!looping) return null;
+                    keyBId = 0;
+                }
+                return keys[keyBId];
+            }
+            else
+            {
+                return nextKey;
+            }
         }
 
         /// <summary>
@@ -193,7 +207,7 @@ namespace SpriterDotNet.Helpers
         /// </summary>
         public static float AdjustTime(float targetTime, SpriterKey keyA, SpriterKey keyB, float animationLength)
         {
-            float nextTime = keyB.Time > keyA.Time ? keyB.Time : animationLength;
+            float nextTime = GetNextTime(keyA, keyB, animationLength);
             float factor = GetFactor(keyA, keyB, animationLength, targetTime);
             return MathHelper.Linear(keyA.Time, nextTime, factor);
         }
@@ -209,12 +223,35 @@ namespace SpriterDotNet.Helpers
             if (timeA > timeB)
             {
                 timeB += animationLength;
+                if (timeA == timeB)
+                {
+                    timeB += animationLength;
+                }
                 if (targetTime < timeA) targetTime += animationLength;
             }
 
             float factor = MathHelper.GetFactor(timeA, timeB, targetTime);
             factor = AdjustFactor(factor, keyA);
             return factor;
+        }
+
+        /// <summary>
+        /// Gets next time for the two keys based on relative keys timeline position.
+        /// </summary>
+        private static float GetNextTime(SpriterKey keyA, SpriterKey keyB, float animationLength)
+        {
+            if (keyA.Time < keyB.Time)
+            {
+                return keyB.Time;
+            }
+            else if (keyB.Time + animationLength == keyA.Time)
+            {
+                return keyA.Time + animationLength;
+            }
+            else
+            {
+                return animationLength;
+            }
         }
     }
 }


### PR DESCRIPTION
Since it’s perfectly fine to have two keys with the same timeline
position and MathHelper’s GetFactor method does not check
a and b values not to be equal, special handling of double key
with the same timeline position is added. This resulted in UnityEngine
errors when assigning local position with coordinate values equal NaN.

Reproduction case is having animation with first key at timeline position
zero and last two keys at timeline position of animation end. When trying
to get FrameData for time equal to animation end, factor calculation would
return NaN.

Maximum duplicate key which can appear in a row is two, for more info see
https://brashmonkey.com/forum/index.php?/topic/4083-multiple-keys-with-the-same-timestamp-in-timeline/

One thing I'm not sure about:

* Change in GetMainlineKeys. If having key with id 1 and key with id 2 as duplicates with timeline position 200 and key with id 3 at position 300, GetMainlineKeys now returns key with id 1 and key with id 3, maybe it should return id 2 and id 3 instead? Not clear from Spriter forum message mentioned above.

Example Spriter project to reproduce issue this pull request fixes:
[DuplicateKeyRepro.zip](https://github.com/loodakrawa/SpriterDotNet/files/2475612/DuplicateKeyRepro.zip)

Closes #98