### PR TITLE
Fixed issue where Spriter could not be included in an Android project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ SpriterDotNet.Unity/*.sln
 SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/*.pdb
 SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/*.pdb.meta
 !SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/*.dll
+/packages

--- a/SpriterDotNet.Example.Content/Content.mgcb
+++ b/SpriterDotNet.Example.Content/Content.mgcb
@@ -13,8 +13,8 @@
 /reference:Lib\Newtonsoft.Json.dll
 /reference:Lib\System.IO.FileSystem.dll
 /reference:Lib\System.Xml.ReaderWriter.dll
-/reference:..\SpriterDotNet.MonoGame.Importer\bin\Debug\netstandard1.4\SpriterDotNet.MonoGame.Importer.dll
-/reference:..\SpriterDotNet.MonoGame.Importer\bin\Release\netstandard1.4\SpriterDotNet.MonoGame.Importer.dll
+/reference:..\SpriterDotNet.MonoGame.Importer\bin\Debug\netstandard2.0\SpriterDotNet.MonoGame.Importer.dll
+/reference:..\SpriterDotNet.MonoGame.Importer\bin\Release\netstandard2.0\SpriterDotNet.MonoGame.Importer.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/SpriterDotNet.Example.MonoGame.Android/Properties/AndroidManifest.xml
+++ b/SpriterDotNet.Example.MonoGame.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="SpriterDotNet.Example.MonoGame..Android" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk />
+	<uses-sdk android:targetSdkVersion="27" />
 	<application android:label="SpriterDotNet.Example.MonoGame.Android"></application>
 </manifest>

--- a/SpriterDotNet.Example.MonoGame.Android/SpriterDotNet.Example.MonoGame.Android.csproj
+++ b/SpriterDotNet.Example.MonoGame.Android/SpriterDotNet.Example.MonoGame.Android.csproj
@@ -12,8 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoGamePlatform>Android</MonoGamePlatform>
   </PropertyGroup>

--- a/SpriterDotNet.Example.MonoGame/SpriterDotNet.Example.MonoGame.csproj
+++ b/SpriterDotNet.Example.MonoGame/SpriterDotNet.Example.MonoGame.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win8+net45+wpa81</PackageTargetFallback>
   </PropertyGroup>
 

--- a/SpriterDotNet.Example.MonoGame/SpriterDotNet.Example.MonoGame.csproj
+++ b/SpriterDotNet.Example.MonoGame/SpriterDotNet.Example.MonoGame.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="MonoGame.Framework.Portable" Version="3.6.0.1625" />
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
   </ItemGroup>

--- a/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
+++ b/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win8+net45+wpa81</PackageTargetFallback>
     <Version>1.6.2</Version>
     <Authors>Luka "loodakrawa" Sverko</Authors>

--- a/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
+++ b/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="MonoGame.Framework.Content.Pipeline.Portable" Version="3.6.0.1625" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />

--- a/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
+++ b/SpriterDotNet.MonoGame.Importer/SpriterDotNet.MonoGame.Importer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win8+net45+wpa81</PackageTargetFallback>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Authors>Luka "loodakrawa" Sverko</Authors>
     <Description>SpriterDotNet MonoGame content extensions.</Description>
     <Copyright>Copyright (C) 2017</Copyright>

--- a/SpriterDotNet.MonoGame/SpriterDotNet.MonoGame.csproj
+++ b/SpriterDotNet.MonoGame/SpriterDotNet.MonoGame.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win8+net45+wpa81</PackageTargetFallback>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Authors>Luka "loodakrawa" Sverko</Authors>
     <Description>SpriterDotNet MonoGame implementation.</Description>
     <Copyright>Copyright (C) 2017</Copyright>
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="MonoGame.Framework.Portable" Version="3.6.0.1625" />
   </ItemGroup>
 

--- a/SpriterDotNet/SpriterDotNet.csproj
+++ b/SpriterDotNet/SpriterDotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Authors>Luka "loodakrawa" Sverko</Authors>
     <Description>A simple, fast and efficient Spriter implementation in pure C#.</Description>
     <Copyright>Copyright (C) 2017</Copyright>


### PR DESCRIPTION
Also updated version to 1.6.2
Upgraded to .net standard so that you can include it in an android project
Fixed minor thing in example android project
added packages folder to .gitignore