### PR TITLE
Resolve "Fix infinite recursion when using cyclic character map"

### DIFF
--- a/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Providers/DefaultAssetProvider.cs
+++ b/SpriterDotNet.Unity/Assets/SpriterDotNet/Lib/Providers/DefaultAssetProvider.cs
@@ -39,7 +39,7 @@ namespace SpriterDotNet.Providers
             {
                 KeyValuePair<int, int> mapping = CharMapValues[asset];
                 if (mapping.Key == folderId && mapping.Value == fileId) return asset;
-                return Get(mapping.Key, mapping.Value);
+                return GetAsset(mapping.Key, mapping.Value);
             }
 
             return SwappedAssets.ContainsKey(asset) ? SwappedAssets[asset] : asset;

--- a/SpriterDotNet/Providers/DefaultAssetProvider.cs
+++ b/SpriterDotNet/Providers/DefaultAssetProvider.cs
@@ -39,7 +39,7 @@ namespace SpriterDotNet.Providers
             {
                 KeyValuePair<int, int> mapping = CharMapValues[asset];
                 if (mapping.Key == folderId && mapping.Value == fileId) return asset;
-                return Get(mapping.Key, mapping.Value);
+                return GetAsset(mapping.Key, mapping.Value);
             }
 
             return SwappedAssets.ContainsKey(asset) ? SwappedAssets[asset] : asset;


### PR DESCRIPTION
Please refer to #112  description for issue details and reproduction steps to verify the fix.

Since `DefaultAssetProvider.Get` method called itself recursively, character map like:

* File 0 is swapped by file 1
* File 1 is swapped by file 2
* File 2 is swapped by file 0

would result in infinite recursion when such character map is applied and entity is animated.
Use `DefaultAssetProvider.GetAsset` instead as `CharMapValues` dictionary contains final data for swapped asset.

Closes #112 
